### PR TITLE
Fix subtitles of interview with Lorenz Knorr (chapter 3)

### DIFF
--- a/locales/en/subtitles/lorenz-knorr/lorenz-knorr-03.yml
+++ b/locales/en/subtitles/lorenz-knorr/lorenz-knorr-03.yml
@@ -6,156 +6,165 @@ en:
       subtitles:
         sequence-1:
           s: 1
-          from: "00:00:00,05"
-          to: "00:00:02,05"
-          text: "Fascism was a subject,"
+          from: 00:00:00,21
+          to: 00:00:05,04
+          text: The party, my parents were functionaries in,
         sequence-2:
           s: 2
-          from: "00:00:02,05"
-          to: "00:00:06,15"
-          text: "because of the experiences that we picked up from the immigrants."
+          from: 00:00:05,04
+          to: 00:00:09,18
+          text: was called the ‘German Social Democratic Labour Party in Czechoslovakia’.
         sequence-3:
           s: 3
-          from: "00:00:06,15"
-          to: "00:00:14,27"
-          text: "In our youth group we invited immigrants from Austria and Germany to tell their story."
+          from: 00:00:09,18
+          to: 00:00:10,14
+          text: ''
         sequence-4:
           s: 4
-          from: "00:00:14,27"
-          to: "00:00:19,24"
-          text: "We already knew before the high finance and the generals"
+          from: 00:00:10,14
+          to: 00:00:15,28
+          text: But the name was a diversion, it was a socialistic, an Austro-Marxian party.
         sequence-5:
           s: 5
-          from: "00:00:19,24"
-          to: "00:00:22,26"
-          text: "pushed the power towards the Nazi leading clique:"
+          from: 00:00:15,28
+          to: 00:00:22,28
+          text: Our party did not belong to the ‘1st Internationale’ but to the ‘2.5th Internationale’,
         sequence-6:
           s: 6
-          from: "00:00:22,26"
-          to: "00:00:24,13"
-          text: "Hitler means war."
+          from: 00:00:22,28
+          to: 00:00:26,18
+          text: 'the ‘Vienna Internationale’, with the slogan:'
         sequence-7:
           s: 7
-          from: "00:00:24,13"
-          to: "00:00:30,00"
-          text: "We not only grew into the anti-fascist fight,"
+          from: 00:00:26,18
+          to: 00:00:33,27
+          text: No social democratic opportunism and no Bolshevistic dogmatism.
         sequence-8:
           s: 8
-          from: "00:00:30,00"
-          to: "00:00:34,04"
-          text: "but as well into the fight for peace. It was the same question to us:"
+          from: 00:00:33,27
+          to: 00:00:34,23
+          text: ''
         sequence-9:
           s: 9
-          from: "00:00:34,04"
-          to: "00:00:36,16"
-          text: "the anti-fascist fight and the fight for peace."
+          from: 00:00:34,23
+          to: 00:00:37,12
+          text: We worked according to this guideline,
         sequence-10:
           s: 10
-          from: "00:00:36,16"
-          to: "00:00:40,25"
-          text: "That obviously assumed that we threw light on it."
+          from: 00:00:37,12
+          to: 00:00:42,13
+          text: but of course even in this party and in the youth association, which was a
+            part of the party,
         sequence-11:
           s: 11
-          from: "00:00:40,25"
-          to: "00:00:49,08"
-          text: "After my youth consecration, when I left school, I took part in my first Marxist seminar."
+          from: 00:00:42,13
+          to: 00:00:44,12
+          text: there were different positions.
         sequence-12:
           s: 12
-          from: "00:00:49,08"
-          to: "00:00:52,29"
-          text: "There, young people who were interested,"
+          from: 00:00:44,12
+          to: 00:00:45,00
+          text: ''
         sequence-13:
           s: 13
-          from: "00:00:52,29"
-          to: "00:01:01,03"
-          text: "learned all the basics if they wanted to become a functionary of the labour movement."
+          from: 00:00:45,00
+          to: 00:00:53,13
+          text: That showed especially in 1936, when the popular front became relevant,
         sequence-14:
           s: 14
-          from: "00:01:01,03"
-          to: "00:01:06,09"
-          text: "So they were not only practical experiences that were being reflected,"
+          from: 00:00:53,13
+          to: 00:00:57,00
+          text: but the politics of the popular front demanded
         sequence-15:
           s: 15
-          from: "00:01:06,09"
-          to: "00:01:14,12"
-          text: "but we also had seminars learning to deal with the political opponent."
+          from: 00:00:57,00
+          to: 00:01:00,01
+          text: for working closely together with the communists.
         sequence-16:
           s: 16
-          from: "00:01:14,12"
-          to: "00:01:19,16"
-          text: "For example, it was obligatory for a functionary of the socialist youth"
+          from: 00:01:00,01
+          to: 00:01:00,28
+          text: ''
         sequence-17:
           s: 17
-          from: "00:01:19,16"
-          to: "00:01:22,29"
-          text: "to have read Hitler’s book ‚Mein Kampf’."
+          from: 00:01:00,28
+          to: 00:01:03,00
+          text: The ideological discrepancies were known.
         sequence-18:
           s: 18
-          from: "00:01:22,29"
-          to: "00:01:31,29"
-          text: "We could tell the Nazi officials, who didn’t know as well as we did, what the real aims were."
+          from: 00:01:03,00
+          to: 00:01:03,28
+          text: ''
         sequence-19:
           s: 19
-          from: "00:01:31,29"
-          to: "00:01:34,25"
-          text: "They did not believe that Hitler wanted war."
+          from: 00:01:03,28
+          to: 00:01:05,02
+          text: They were out of question.
         sequence-20:
           s: 20
-          from: "00:01:34,25"
-          to: "00:01:36,08"
-          text: ~
+          from: 00:01:05,02
+          to: 00:01:08,14
+          text: We shared the same enemy, which was fascism
         sequence-21:
           s: 21
-          from: "00:01:36,08"
-          to: "00:01:40,16"
-          text: "We kept hearing again and again:  „They will not be so stupid to go against the whole world on their own.”"
+          from: 00:01:08,14
+          to: 00:01:14,13
+          text: and which had to be fought together - within the popular front.
         sequence-22:
           s: 22
-          from: "00:01:40,16"
-          to: "00:01:47,07"
-          text: "But we were able to quote from ‚Mein Kampf’ that the annexation of new living space in the east"
+          from: 00:01:14,13
+          to: 00:01:24,16
+          text: In Léon Blum in France we had the example of a socialist of the popular front,
+            socialists, communists and the radical socialists.
         sequence-23:
           s: 23
-          from: "00:01:47,07"
-          to: "00:01:51,05"
-          text: "was one main issue of the Nazis’ fight."
+          from: 00:01:24,16
+          to: 00:01:31,28
+          text: That were the civil liberals, who wanted to fight the fascism together and
+            with us it was the same.
         sequence-24:
           s: 24
-          from: "00:01:51,05"
-          to: "00:01:57,25"
-          text: "If we were able to bring the better arguments into discussions with the Nazis,"
+          from: 00:01:31,28
+          to: 00:01:36,05
+          text: 'At the basis nobody asked anymore: “Where do you come from?'
         sequence-25:
           s: 25
-          from: "00:01:57,25"
-          to: "00:02:03,11"
-          text: "in the companies, in the schools or wherever, it would have an effect on the undecided."
+          from: 00:01:36,05
+          to: 00:01:42,00
+          text: Are you from the CY, the communistic youth, the socialist youth or the ’Bündische
+            Jugend’?”
         sequence-26:
           s: 26
-          from: "00:02:03,11"
-          to: "00:02:06,05"
-          text: "But still the Nazis became stronger and stronger;"
+          from: 00:01:42,00
+          to: 00:01:46,27
+          text: 'The question was: „What can you do against fascism?“'
         sequence-27:
           s: 27
-          from: "00:02:06,05"
-          to: "00:02:10,04"
-          text: "for one, because of the social problems and for two,"
+          from: 00:01:46,27
+          to: 00:01:48,03
+          text: ''
         sequence-28:
           s: 28
-          from: "00:02:10,04"
-          to: "00:02:16,16"
-          text: "because the imperial German broadcasting service had an immense influence."
+          from: 00:01:48,03
+          to: 00:01:53,02
+          text: Because we followed the example of France,
         sequence-29:
           s: 29
-          from: "00:02:16,16"
-          to: "00:02:18,27"
-          text: "Many Germans did not speak Czech,"
+          from: 00:01:53,02
+          to: 00:01:59,17
+          text: the calling up of German intellectuals from Paris,
         sequence-30:
           s: 30
-          from: "00:02:18,27"
-          to: "00:02:25,08"
-          text: "but you could hear the broadcast stations Königs Wusterhausen and Seesen, the two Nazi stations, well."
+          from: 00:01:59,17
+          to: 00:02:05,09
+          text: all dividing differences on the left had to be put aside,
         sequence-31:
           s: 31
-          from: "00:02:25,08"
-          to: "00:02:38,04"
-          text: "This influence, in which social problems were misleadingly passed off as national problems, were surely effective."
+          from: 00:02:05,09
+          to: 00:02:10,11
+          text: to concentrate the strength against the fascist attack,
+        sequence-32:
+          s: 32
+          from: 00:02:10,11
+          to: 00:02:13,00
+          text: which was going on everywhere at that time.


### PR DESCRIPTION
This PR adds the correct English subtitles for [Chapter 3 of the interview with Lorenz Knorr](https://www.resistance-archive.org/en/testimonies/lorenz-knorr/#/clips/t9As-lIWZy4).

Hint: For some reason the subtitles for chapter 3 contained the content of chapter 4.

Big thanks to **Björn Luley** who found and reported the bug! 